### PR TITLE
Add IgnoreMap and IgnoreList options to Map List Config

### DIFF
--- a/Classes/VS_MapListConfig.uc
+++ b/Classes/VS_MapListConfig.uc
@@ -2,6 +2,8 @@ class VS_MapListConfig extends Object
 	perobjectconfig;
 
 var config array<string> Map;
-var config array<string> IncludeMapsWithPrefix;
 var config array<string> IgnoreMap;
+var config array<string> IncludeMapsWithPrefix;
+var config array<string> IgnoreMapsWithPrefix;
+var config array<name> IncludeList;
 var config array<name> IgnoreList;

--- a/Classes/VS_MapListConfig.uc
+++ b/Classes/VS_MapListConfig.uc
@@ -3,3 +3,5 @@ class VS_MapListConfig extends Object
 
 var config array<string> Map;
 var config array<string> IncludeMapsWithPrefix;
+var config array<string> IgnoreMap;
+var config array<name> IgnoreList;

--- a/README.md
+++ b/README.md
@@ -372,17 +372,34 @@ Map=DM-Agony
 Map=DM-StalwartXL
 Map=DM-Morpheus
 
+[CustomMapListNoAgony]
+IncludeList=CustomMapList
+IgnoreMap=DM-Agony
+
+[DMMapsNotInCustomMapList]
+IncludeMapsWithPrefix=DM-
+IgnoreList=CustomMapList
+
 [BTMaps]
 Map=CTF-AwesomeBTMap
 IncludeMapsWithPrefix=CTF-BT+
 IncludeMapsWithPrefix=CTF-BT-
+
+[CTFbutNotVCTFNorBTMaps]
+IncludeMapsWithPrefix=CTF-
+IgnoreMapsWithPrefix=CTF-XV-
+IgnoreList=BTMaps
 ```
+Map lists are specified in this file. To build the map list, VoteSys will first gather up all included maps, and then will remove any ignored maps. Ignored maps will always take precedence over included ones, and the ordering of included vs. ignored ones will not make a difference. If you want to include a map that was previously ignored, you can make another map list that includes it and the map list in question.
 
-#### Map
-Specify individual maps to add to the map list.
+#### Map/IgnoreMap
+Specify individual maps to add or remove from the map list.
 
-#### IncludeMapsWithPrefix
-Adds all maps that match any of the specified prefixes to the map list.
+#### IncludeMapsWithPrefix/IgnoreMapsWithPrefix
+Adds or removes all maps that match a specified prefix from the map list.
+
+#### IncludeList/IgnoreList
+Adds or removes all maps in another map list from the map list.
 
 ## Build
 In order to build this mutator, you need to be using UT99 v469c.

--- a/System/VoteSysMapLists.ini
+++ b/System/VoteSysMapLists.ini
@@ -4,7 +4,20 @@ Map=DM-Agony
 Map=DM-StalwartXL
 Map=DM-Morpheus
 
+[CustomMapListNoAgony]
+IncludeList=CustomMapList
+IgnoreMap=DM-Agony
+
+[DMMapsNotInCustomMapList]
+IncludeMapsWithPrefix=DM-
+IgnoreList=CustomMapList
+
 [BTMaps]
 Map=CTF-AwesomeBTMap
 IncludeMapsWithPrefix=CTF-BT+
 IncludeMapsWithPrefix=CTF-BT-
+
+[CTFbutNotVCTFNorBTMaps]
+IncludeMapsWithPrefix=CTF-
+IgnoreMapsWithPrefix=CTF-XV-
+IgnoreList=BTMaps


### PR DESCRIPTION
I have a `VoteSysMapList.ini` like this:
```
[CTF_Maps]
IncludeMapsWithPrefix=CTF-
IgnoreList=CTF_XV_Maps
IgnoreList=CTF_W00t_Maps
IgnoreMap=CTF-Beatitude

[CTF_XV_Maps]
IncludeMapsWithPrefix=CTF-XV-

[CTF_W00t_Maps]
Map=CTF-Airie
Map=CTF-AllYourFacingW00t
Map=CTF-AllYourW00t-SE
Map=CTF-AnotherBrickInTheW00t
```
With this pull request, the `LoadMapList()` function is recursively called to load each `IgnoreList` into one `VS_MapList`, which is then used to filter out maps from any `IncludeMapsWithPrefix` entries. It also allows `IgnoreMap` for ignoring one-off maps, and it won't filter out maps included with `Map`.

Add `IncludeMapsWithPrefix` -> filter out `IgnoreList` and `IgnoreMap` -> add back `Map`. (The code doesn't actually work in that order, but logically it does).

I tried to keep this as simple as possible, and in the same style. Please feel free to make any edits, or let me know if you want me to make any changes. The only thing that sort of bugs me is that when it recursively loads `IgnoreList` entries, it shows the `Loading List 'CTF_XV_Maps' for Botpack.CTFGame` log message, which is technically true, but you can't tell if it's loading for including or excluding. But I thought adding another parameter to the `LoadMapList()` just to change a log statement was overkill.